### PR TITLE
ci: publish when version is unpublished

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
   pull_request:
-  workflow_dispatch: null
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,7 +22,20 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run prepublishOnly
-      - run: npm publish --access public
+      - name: Check if version is already published
+        id: version-check
         if: github.event_name != 'pull_request'
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version > /dev/null 2>&1; then
+            echo "Version $PKG_VERSION of $PKG_NAME is already published, skipping publish."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version $PKG_VERSION of $PKG_NAME is new, will publish."
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          fi
+      - run: npm publish --access public
+        if: github.event_name != 'pull_request' && steps.version-check.outputs.should-publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
currently, we try to publish all commits to main

this PR uses `npm view` to check whether the current version is on npm already, if not, publishes it (main only, on push or manual trigger)